### PR TITLE
Support atomic update

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -496,6 +496,7 @@ class File {
         }
         // Same event name - it's an atomic update
         this.unsubscribeFromNativeChangeEvents();
+        this.subscribeToNativeChangeEvents(); // because the inode changed
       case 'change':
       case 'resurrect':
         this.cachedContents = null;

--- a/src/file.js
+++ b/src/file.js
@@ -494,7 +494,7 @@ class File {
           this.emitter.emit('did-rename');
           return;
         }
-        // Same event name - it's an atomic update
+        // Same file name - it's an atomic update
         this.unsubscribeFromNativeChangeEvents();
         this.subscribeToNativeChangeEvents(); // because the inode changed
       case 'change':

--- a/src/file.js
+++ b/src/file.js
@@ -485,13 +485,17 @@ class File {
         this.detectResurrectionAfterDelay();
         return;
       case 'rename':
-        this.setPath(eventPath);
-        this.subscribeToNativeChangeEvents();
-        if (Grim.includeDeprecatedAPIs) {
-          this.emit('moved');
+        if (eventPath !== this.path) {
+          this.setPath(eventPath);
+          this.subscribeToNativeChangeEvents();
+          if (Grim.includeDeprecatedAPIs) {
+            this.emit('moved');
+          }
+          this.emitter.emit('did-rename');
+          return;
         }
-        this.emitter.emit('did-rename');
-        return;
+        // Same event name - it's an atomic update
+        this.unsubscribeFromNativeChangeEvents();
       case 'change':
       case 'resurrect':
         this.cachedContents = null;


### PR DESCRIPTION
For automated updates of files, most tools support atomic updates - it essentially creates a new file, fills it with the contents, and rename this new file to the one being "changed".

Pathwatcher emits a `did-rename` on this case, but if we're watching a file with a name `foo.txt`, we don't want to know that it was "renamed" to `foo.txt` - we want a `did-change`. This PR implements this.

I tested on my local copy of Pulsar, and the errors I was experiencing (tools that provoke an atomic update not changing the editor) are now fixed.